### PR TITLE
Correção no cálculo de taxa de rendimento

### DIFF
--- a/components/InvestmentInput.vue
+++ b/components/InvestmentInput.vue
@@ -4,7 +4,10 @@
     <v-card-text>
       <v-form @submit.prevent="submit">
         <AmountInput />
-        <DurationInput />
+        <div class="duration-container">
+          <DurationInput />
+          <DurationTypeInput />
+        </div>
         <IndexDiInput />
         <IndexSelicInput />
         <IndexCdbInput />
@@ -15,6 +18,7 @@
 </template>
 <script>
 import AmountInput from './investment/AmountInput.vue'
+import DurationTypeInput from './investment/DurationTypeInput.vue'
 import DurationInput from './investment/DurationInput.vue'
 import IndexDiInput from './investment/IndexDiInput.vue'
 import IndexSelicInput from './investment/IndexSelicInput.vue'
@@ -23,6 +27,7 @@ import IndexLcxInput from './investment/IndexLcxInput.vue'
 export default {
   components: {
     AmountInput,
+    DurationTypeInput,
     DurationInput,
     IndexDiInput,
     IndexSelicInput,
@@ -31,3 +36,11 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.duration-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+</style>

--- a/components/InvestmentSimulation.vue
+++ b/components/InvestmentSimulation.vue
@@ -32,11 +32,17 @@ import InvestmentResult from './InvestmentResult.vue'
 import { getCDBResult } from '~/src/cdb'
 import { getLcxResult } from '~/src/lcx'
 import { getPoupancaResult } from '~/src/poupanca'
+import { DurationType } from '~/store/investment'
 export default {
   components: { InvestmentResult },
   data() {
     return {
-      investment: this.$store.state.investment
+      investment: this.$store.state.investment,
+      periodMultiplier: {
+        [DurationType.Days]: 1,
+        [DurationType.Months]: 365 / 12,
+        [DurationType.Years]: 365
+      }
     }
   },
   computed: {
@@ -45,7 +51,7 @@ export default {
         this.investment.amount,
         this.investment.di,
         this.investment.cdb,
-        this.investment.duration
+        this.getDurationInDays()
       )
     },
     resultLcx() {
@@ -53,14 +59,22 @@ export default {
         this.investment.amount,
         this.investment.di,
         this.investment.lcx,
-        this.investment.duration
+        this.getDurationInDays()
       )
     },
     resultPoupanca() {
       return getPoupancaResult(
         this.investment.amount,
         this.investment.poupanca,
-        this.investment.duration
+        this.getDurationInDays()
+      )
+    }
+  },
+  methods: {
+    getDurationInDays() {
+      return Math.floor(
+        this.investment.duration *
+          this.periodMultiplier[this.investment.durationType]
       )
     }
   }

--- a/components/investment/DurationInput.vue
+++ b/components/investment/DurationInput.vue
@@ -4,7 +4,6 @@
     type="number"
     label="Vencimento"
     prepend-icon="mdi-calendar"
-    suffix="meses"
     min="1"
     :rules="[rules.required, rules.positive]"
   />

--- a/components/investment/DurationTypeInput.vue
+++ b/components/investment/DurationTypeInput.vue
@@ -1,0 +1,27 @@
+<template>
+  <v-select
+    v-model="durationType"
+    label="Tipo de período"
+    :items="durationTypeOptions"
+    density="compact"
+  ></v-select>
+</template>
+<script>
+export default {
+  computed: {
+    durationTypeOptions: {
+      get() {
+        return this.$store.state.investment.durationTypeOptions
+      }
+    },
+    durationType: {
+      get() {
+        return this.$store.state.investment.durationType
+      },
+      set(value) {
+        this.$store.commit('investment/setDurationType', value)
+      }
+    }
+  }
+}
+</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,10 +45,10 @@
         "lint-staged": "^13.0.3",
         "postcss-html": "^1.3.0",
         "prettier": "^2.5.1",
-        "stylelint": "^14.1.0",
-        "stylelint-config-prettier": "^9.0.3",
-        "stylelint-config-recommended-vue": "^1.1.0",
-        "stylelint-config-standard": "^28.0.0",
+        "stylelint": "^14.16.1",
+        "stylelint-config-prettier": "^9.0.5",
+        "stylelint-config-recommended-vue": "^1.4.0",
+        "stylelint-config-standard": "^29.0.0",
         "ts-jest": "^27.1.1",
         "vue-jest": "^3.0.4"
       }
@@ -11753,9 +11753,9 @@
       "integrity": "sha512-DUNFN5j7Tln0D+TxzloUjKB+CtVu6myn0JEFak6dG18mNt9YkQ6lzGCdafwofISZ1lLF3xRHJ98VKy9ynkcFaA=="
     },
     "node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "engines": {
         "node": ">= 4"
       }
@@ -19649,9 +19649,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "14.15.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.15.0.tgz",
-      "integrity": "sha512-JOgDAo5QRsqiOZPZO+B9rKJvBm64S0xasbuRPAbPs6/vQDgDCnZLIiw6XcAS6GQKk9k1sBWR6rmH3Mfj8OknKg==",
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
+      "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
       "dependencies": {
         "@csstools/selector-specificity": "^2.0.2",
@@ -19667,7 +19667,7 @@
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^3.2.0",
-        "ignore": "^5.2.0",
+        "ignore": "^5.2.1",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
@@ -19681,7 +19681,7 @@
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
         "string-width": "^4.2.3",
@@ -19721,9 +19721,9 @@
       }
     },
     "node_modules/stylelint-config-prettier": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
-      "integrity": "sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.5.tgz",
+      "integrity": "sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==",
       "dev": true,
       "bin": {
         "stylelint-config-prettier": "bin/check.js",
@@ -19733,7 +19733,7 @@
         "node": ">= 12"
       },
       "peerDependencies": {
-        "stylelint": ">=11.0.0"
+        "stylelint": ">= 11.x < 15"
       }
     },
     "node_modules/stylelint-config-recommended": {
@@ -19800,15 +19800,15 @@
       "dev": true
     },
     "node_modules/stylelint-config-standard": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-28.0.0.tgz",
-      "integrity": "sha512-q/StuowDdDmFCravzGHAwgS9pjX0bdOQUEBBDIkIWsQuYGgYz/xsO8CM6eepmIQ1fc5bKdDVimlJZ6MoOUcJ5Q==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-29.0.0.tgz",
+      "integrity": "sha512-uy8tZLbfq6ZrXy4JKu3W+7lYLgRQBxYTUUB88vPgQ+ZzAxdrvcaSUW9hOMNLYBnwH+9Kkj19M2DHdZ4gKwI7tg==",
       "dev": true,
       "dependencies": {
         "stylelint-config-recommended": "^9.0.0"
       },
       "peerDependencies": {
-        "stylelint": "^14.11.0"
+        "stylelint": "^14.14.0"
       }
     },
     "node_modules/stylelint/node_modules/@csstools/selector-specificity": {
@@ -32196,9 +32196,9 @@
       "integrity": "sha512-DUNFN5j7Tln0D+TxzloUjKB+CtVu6myn0JEFak6dG18mNt9YkQ6lzGCdafwofISZ1lLF3xRHJ98VKy9ynkcFaA=="
     },
     "ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -38296,9 +38296,9 @@
       }
     },
     "stylelint": {
-      "version": "14.15.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.15.0.tgz",
-      "integrity": "sha512-JOgDAo5QRsqiOZPZO+B9rKJvBm64S0xasbuRPAbPs6/vQDgDCnZLIiw6XcAS6GQKk9k1sBWR6rmH3Mfj8OknKg==",
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
+      "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
       "requires": {
         "@csstools/selector-specificity": "^2.0.2",
@@ -38314,7 +38314,7 @@
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^3.2.0",
-        "ignore": "^5.2.0",
+        "ignore": "^5.2.1",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
@@ -38328,7 +38328,7 @@
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
         "string-width": "^4.2.3",
@@ -38440,9 +38440,9 @@
       "requires": {}
     },
     "stylelint-config-prettier": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
-      "integrity": "sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.5.tgz",
+      "integrity": "sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==",
       "dev": true,
       "requires": {}
     },
@@ -38491,9 +38491,9 @@
       }
     },
     "stylelint-config-standard": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-28.0.0.tgz",
-      "integrity": "sha512-q/StuowDdDmFCravzGHAwgS9pjX0bdOQUEBBDIkIWsQuYGgYz/xsO8CM6eepmIQ1fc5bKdDVimlJZ6MoOUcJ5Q==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-29.0.0.tgz",
+      "integrity": "sha512-uy8tZLbfq6ZrXy4JKu3W+7lYLgRQBxYTUUB88vPgQ+ZzAxdrvcaSUW9hOMNLYBnwH+9Kkj19M2DHdZ4gKwI7tg==",
       "dev": true,
       "requires": {
         "stylelint-config-recommended": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "lint-staged": "^13.0.3",
     "postcss-html": "^1.3.0",
     "prettier": "^2.5.1",
-    "stylelint": "^14.1.0",
-    "stylelint-config-prettier": "^9.0.3",
-    "stylelint-config-recommended-vue": "^1.1.0",
-    "stylelint-config-standard": "^28.0.0",
+    "stylelint": "^14.16.1",
+    "stylelint-config-prettier": "^9.0.5",
+    "stylelint-config-recommended-vue": "^1.4.0",
+    "stylelint-config-standard": "^29.0.0",
     "ts-jest": "^27.1.1",
     "vue-jest": "^3.0.4"
   }

--- a/src/cdb.js
+++ b/src/cdb.js
@@ -13,5 +13,5 @@ export function getCDBResult(amount, di, yearlyIndex, periods) {
 
 function getIndexCDB(yearlyInterest, di) {
   const index = yearlyInterest / 100
-  return Math.pow((index * di) / 100 + 1, 1 / 12)
+  return Math.pow((index * di) / 100 + 1, 1 / 365)
 }

--- a/src/finance.js
+++ b/src/finance.js
@@ -1,13 +1,13 @@
-export function compoundInterest(amount, index, periods) {
-  return amount * Math.pow(index, periods) - amount
+export function compoundInterest(amount, index, days) {
+  return amount * Math.pow(index, days) - amount
 }
 
-export function getIndexIR(periods) {
-  if (periods <= 6) {
+export function getIndexIR(days) {
+  if (days <= 180) {
     return 22.5
-  } else if (periods <= 12) {
+  } else if (days <= 360) {
     return 20
-  } else if (periods <= 24) {
+  } else if (days <= 720) {
     return 17.5
   } else {
     return 15

--- a/src/lcx.js
+++ b/src/lcx.js
@@ -11,5 +11,5 @@ export function getLcxResult(amount, di, yearlyIndex, periods) {
 
 function getIndexLcx(yearlyInterest, di) {
   const index = yearlyInterest / 100
-  return Math.pow((index * di) / 100 + 1, 1 / 12)
+  return Math.pow((index * di) / 100 + 1, 1 / 365)
 }

--- a/src/poupanca.js
+++ b/src/poupanca.js
@@ -4,11 +4,15 @@ export function getPoupancaResult(amount, index, periods) {
   const interestAmount = finance.compoundInterest(
     amount,
     getIndexPoupanca(index),
-    periods
+    calculateFullMonthsDays(periods)
   )
-  const taxAmount = 0
-  const taxPercentage = 0
-  return { interestAmount, taxAmount, taxPercentage }
+
+  return { interestAmount }
+}
+
+export function calculateFullMonthsDays(days) {
+  const daysInMonth = 30
+  return days < daysInMonth ? 0 : Math.floor(days / daysInMonth) * daysInMonth
 }
 
 function getIndexPoupanca(index) {

--- a/src/poupanca.js
+++ b/src/poupanca.js
@@ -12,5 +12,5 @@ export function getPoupancaResult(amount, index, periods) {
 }
 
 function getIndexPoupanca(index) {
-  return index / 100 + 1
+  return Math.pow(index / 100 + 1, 1 / 30)
 }

--- a/store/investment.js
+++ b/store/investment.js
@@ -1,6 +1,12 @@
+export const DurationType = {
+  Days: 'Dias',
+  Months: 'Meses',
+  Years: 'Anos'
+}
 const defaultAmount = 1000
 const defaultCdb = 100
 const defaultDuration = 12
+const defaultDurationType = DurationType.Months
 const defaultLcx = 100
 
 export const state = () => ({
@@ -8,6 +14,8 @@ export const state = () => ({
   cdb: defaultCdb,
   di: null,
   duration: defaultDuration,
+  durationType: defaultDurationType,
+  durationTypeOptions: Object.values(DurationType),
   lcx: defaultLcx,
   poupanca: null,
   selic: null
@@ -25,6 +33,10 @@ export const mutations = {
   setDuration(state, newDuration) {
     state.duration = newDuration
     localStorage.setItem('investment.duration', newDuration)
+  },
+  setDurationType(state, newDurationType) {
+    state.durationType = newDurationType
+    localStorage.setItem('investment.durationType', newDurationType)
   },
   setDi(state, newDi) {
     state.di = newDi
@@ -48,6 +60,8 @@ export const mutations = {
     state.cdb = localStorage.getItem('investment.cdb') || defaultCdb
     state.duration =
       localStorage.getItem('investment.duration') || defaultDuration
+    state.durationType =
+      localStorage.getItem('investment.durationType') || defaultDurationType
     state.di = localStorage.getItem('investment.di')
     state.lcx = localStorage.getItem('investment.lcx') || defaultLcx
     state.selic = localStorage.getItem('investment.selic')

--- a/test/cdb.spec.js
+++ b/test/cdb.spec.js
@@ -1,0 +1,56 @@
+import * as cdb from '@/src/cdb'
+const each = require('jest-each').default
+
+describe('getCDBResult', () => {
+  each([
+    [
+      1000,
+      12,
+      100,
+      30,
+      {
+        interestAmount: 9.358203165413329,
+        taxAmount: 2.105595712217999,
+        taxPercentage: 22.5
+      }
+    ],
+    [
+      1000,
+      12,
+      100,
+      200,
+      {
+        interestAmount: 64.06652212284939,
+        taxAmount: 12.813304424569878,
+        taxPercentage: 20
+      }
+    ],
+    [
+      1000,
+      12,
+      100,
+      721,
+      {
+        interestAmount: 250.89959025071857,
+        taxAmount: 37.63493853760779,
+        taxPercentage: 15
+      }
+    ],
+    [
+      1000,
+      12,
+      100,
+      720,
+      {
+        interestAmount: 250.51125929083673,
+        taxAmount: 43.839470375896425,
+        taxPercentage: 17.5
+      }
+    ]
+  ]).it(
+    'when the value is %s and the index %s, invested for %s days, the return will be %s',
+    (amount, di, index, periods, result) => {
+      expect(cdb.getCDBResult(amount, di, index, periods)).toEqual(result)
+    }
+  )
+})

--- a/test/finance.spec.js
+++ b/test/finance.spec.js
@@ -3,15 +3,15 @@ const each = require('jest-each').default
 
 describe('getIndexIR', () => {
   each([
-    [1, 22.5],
-    [5, 22.5],
-    [6, 22.5],
-    [7, 20],
-    [12, 20],
-    [13, 17.5],
-    [23, 17.5],
-    [24, 17.5],
-    [25, 15]
+    [30, 22.5],
+    [60, 22.5],
+    [180, 22.5],
+    [181, 20],
+    [250, 20],
+    [360, 20],
+    [361, 17.5],
+    [720, 17.5],
+    [730, 15]
   ]).it('when period is %s then IR index is %s', (periods, result) => {
     expect(finance.getIndexIR(periods)).toBe(result)
   })

--- a/test/lcx.spec.js
+++ b/test/lcx.spec.js
@@ -1,0 +1,16 @@
+import * as lcx from '@/src/lcx'
+const each = require('jest-each').default
+
+describe('getCDBResult', () => {
+  each([
+    [1000, 12, 100, 30, { interestAmount: 9.358203165413329 }],
+    [1000, 12, 100, 200, { interestAmount: 64.06652212284939 }],
+    [1000, 12, 100, 721, { interestAmount: 250.89959025071857 }],
+    [1000, 12, 100, 720, { interestAmount: 250.51125929083673 }]
+  ]).it(
+    'when the value is %s and the index %s, invested for %s days, the return will be %s',
+    (amount, di, index, periods, result) => {
+      expect(lcx.getLcxResult(amount, di, index, periods)).toEqual(result)
+    }
+  )
+})

--- a/test/poupanca.spec.js
+++ b/test/poupanca.spec.js
@@ -1,0 +1,30 @@
+import * as poupanca from '@/src/poupanca'
+const each = require('jest-each').default
+
+describe('calculateFullMonthsDays', () => {
+  each([
+    [0, 0],
+    [29, 0],
+    [30, 30],
+    [200, 180],
+    [365, 360]
+  ]).it('when the number of days is %s then return %s', (periods, result) => {
+    expect(poupanca.calculateFullMonthsDays(periods)).toBe(result)
+  })
+})
+
+describe('getPoupancaResult', () => {
+  each([
+    [1000, 0.65, 30, 6.500000000002615],
+    [1000, 0.65, 35, 6.500000000002615],
+    [1000, 0.65, 180, 39.6392693456462],
+    [1000, 0.65, 365, 80.84981036554882]
+  ]).it(
+    'when the value is %s and the index %s, invested for %s days, the return will be %s',
+    (amount, index, periods, result) => {
+      expect(poupanca.getPoupancaResult(amount, index, periods)).toEqual({
+        interestAmount: result
+      })
+    }
+  )
+})


### PR DESCRIPTION
Corrigido o problema no cálculo da taxa de rendimento do CDB, agora o calculo é sempre baseado em dias.
Também implementei uma seleção para que seja possível usar o sistema em dias, meses ou anos.

![image](https://github.com/rendafixa/rendafixa.github.io/assets/28936627/db18d911-a3db-4f79-a7bf-5fd339c725b4)

closes #51 