### PR TITLE
Fix: replace cetip domain by bcb

### DIFF
--- a/store/investment.ts
+++ b/store/investment.ts
@@ -54,9 +54,13 @@ export const useInvestmentStore = defineStore('investment', {
         .catch((error) => console.log(error));
     },
     fetchDi() {
-      fetch('https://www2.cetip.com.br/ConsultarTaxaDi/ConsultarTaxaDICetip.aspx')
+      fetch('https://api.bcb.gov.br/dados/serie/bcdata.sgs.4391/dados/ultimos/13?formato=json')
         .then((response) => response.json())
-        .then((data) => this.di = parseFloat(data.taxa.replace(/[.]/g, '').replace(',', '.')))
+        .then((data: { valor: string }[]) => this.di = data
+          .slice(1) // Ignores the partial value of current month
+          .map((item: any) => parseFloat(item.valor))
+          .reduce((acc, value) => acc + value, 0)
+        )
         .catch((error) => console.log(error));
     },
     fetchSelic() {


### PR DESCRIPTION
Parece que está rolando alguns problemas com CETIP e BCB:

<img width="1304" alt="image" src="https://github.com/user-attachments/assets/083b162e-62f8-49f2-99dd-1b5fda87cb4b">

E isso impede a obtenção da Taxa DI e Taxa Selic. Encontrei outras APIs referenciadas em [outro projeto]( https://github.com/Tpessia/dados-financeiros/blob/main/README.md) que podem ajudar - eu tive dificuldade de encontrar as fontes certas no portal de dados abertos.

Esse PR tenta contornar o problema com o CETIP através da taxa acumulada dos últimos 12 meses completos (ignorando sempre o mês atual, considerado incompleto sempre).

Se esta solução fizer sentido e funcionar em produção (sem problemas de CORS), então podemos tentar fazer algo parecido para a Taxa Selic.
