### PR TITLE
Adiciona rendimento líquido

### DIFF
--- a/components/InvestmentResult.vue
+++ b/components/InvestmentResult.vue
@@ -16,6 +16,9 @@
             color='red lighten-2'
           />
         </div>
+        <div>
+          Rendimento Líquido: {{ liquidAmountDisplay }}
+        </div>
         <div>Valor Total Líquido: {{ totalAmountDisplay }}</div>
         <v-progress-linear v-model='totalProfitPercentage' :color='color' height='25'>
           {{ totalProfitPercentageDisplay }}
@@ -93,6 +96,7 @@ const taxPercentageDisplay = computed(() => filters.percent(props.taxPercentage)
 const taxAmountDisplay = computed(() => filters.currency(props.taxAmount))
 const amountDisplay = computed(() => filters.currency(props.amount))
 const iofAmountDisplay = computed(() => filters.currency(props.iofAmount))
+const liquidAmountDisplay = computed(() => filters.currency(totalProfit.value))
 const totalAmountDisplay = computed(() => filters.currency(totalAmount.value))
 const interestAmountDisplay = computed(() => filters.currency(props.interestAmount))
 const totalProfitPercentageDisplay = computed(() => filters.percent(totalProfitPercentage.value))


### PR DESCRIPTION
Muitas vezes quando acessei a calculadora só queria saber qual o valor do rendimento líquido, porém na interface só consta os valores finais e de rendimento bruto, eu tinha que fazer a conta mentalmente (ou na calculadora). Para alguns valores redondos tipo 10.000 era até fácil, mas para valores quebrados não.

Este PR adiciona o valor de **rendimento líquido** à UI.

![image](https://github.com/user-attachments/assets/1545bc38-9da8-4106-ad89-2b14e38894cb)
