### PR TITLE
feat: adiciona aportes recorrentes com correção pela inflação

### DIFF
--- a/app/components/InvestmentInput.vue
+++ b/app/components/InvestmentInput.vue
@@ -6,6 +6,7 @@ import IndexCdbInput from '~/components/investment/IndexCdbInput.vue'
 import IndexLcxInput from '~/components/investment/IndexLcxInput.vue'
 import PeriodInput from './investment/PeriodInput.vue'
 import PeriodTypeInput from './investment/PeriodTypeInput.vue'
+import RecurringContributionInput from './investment/RecurringContributionInput.vue'
 </script>
 
 <template>
@@ -22,6 +23,7 @@ import PeriodTypeInput from './investment/PeriodTypeInput.vue'
           <PeriodInput />
           <PeriodTypeInput />
         </div>
+        <RecurringContributionInput />
         <IndexDiInput />
         <IndexSelicInput />
         <IndexCdbInput />

--- a/app/components/InvestmentResult.vue
+++ b/app/components/InvestmentResult.vue
@@ -125,12 +125,77 @@
           <span class="text-sm font-semibold text-red-700 dark:text-red-400">-{{ iofAmountDisplay }}</span>
         </div>
       </div>
+
+      <!-- Recurring contributions breakdown - shown on demand -->
+      <div
+        v-if="breakdown.length"
+        class="mt-4"
+      >
+        <button
+          type="button"
+          class="flex items-center gap-1 text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+          :aria-expanded="showBreakdown"
+          @click="showBreakdown = !showBreakdown"
+        >
+          <ion-icon
+            :name="showBreakdown ? 'chevron-up-outline' : 'chevron-down-outline'"
+            size="small"
+            aria-hidden="true"
+          />
+          Ver evolução dos aportes
+        </button>
+        <div
+          v-if="showBreakdown"
+          class="mt-3 overflow-x-auto"
+        >
+          <table class="w-full text-sm text-right">
+            <thead>
+              <tr class="text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                <th class="py-2 pr-3 text-left font-medium">
+                  Dia
+                </th>
+                <th class="py-2 px-3 font-medium">
+                  Aportado
+                </th>
+                <th class="py-2 px-3 font-medium">
+                  Saldo bruto
+                </th>
+                <th class="py-2 pl-3 font-medium">
+                  Juros
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="entry in breakdown"
+                :key="entry.day"
+                class="border-b border-gray-100 dark:border-gray-700/50"
+              >
+                <td class="py-2 pr-3 text-left text-gray-600 dark:text-gray-400">
+                  {{ entry.day }}
+                </td>
+                <td class="py-2 px-3 text-gray-900 dark:text-gray-100">
+                  {{ filters.currency(entry.contributed) }}
+                </td>
+                <td class="py-2 px-3 font-semibold text-gray-900 dark:text-gray-100">
+                  {{ filters.currency(entry.balance) }}
+                </td>
+                <td class="py-2 pl-3 text-green-700 dark:text-green-400">
+                  {{ filters.currency(entry.interest) }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang='ts'>
-import { computed } from 'vue'
+import type { PropType } from 'vue'
+import type { BreakdownEntry } from '~/src/aportes'
+import { computed, ref } from 'vue'
 
 const defaultLocale = 'pt-BR'
 const filters = {
@@ -187,7 +252,14 @@ const props = defineProps({
     required: false,
     default: 'amber',
   },
+  breakdown: {
+    type: Array as PropType<BreakdownEntry[]>,
+    required: false,
+    default: () => [],
+  },
 })
+
+const showBreakdown = ref(false)
 
 const hasInterestAmount = computed(() => props.interestAmount !== 0)
 const hasTaxAmount = computed(() => props.taxAmount !== null && props.taxAmount !== undefined && props.taxAmount !== 0)

--- a/app/components/InvestmentSimulation.vue
+++ b/app/components/InvestmentSimulation.vue
@@ -9,26 +9,29 @@
     </p>
     <InvestmentResult
       name="Poupança"
-      :amount="investment.amount"
+      :amount="totalContributed"
       :interest-amount="resultPoupanca.interestAmount"
       :loading="!investment.poupanca"
+      :breakdown="breakdownPoupanca"
       class="mb-2"
     />
     <InvestmentResult
       name="CDB / RDB"
-      :amount="investment.amount"
+      :amount="totalContributed"
       :interest-amount="resultCDB.interestAmount"
       :tax-amount="resultCDB.taxAmount"
       :tax-percentage="resultCDB.taxPercentage"
       :loading="!investment.di"
       :iof-amount="resultCDB.iofAmount"
+      :breakdown="breakdownCDB"
       class="mb-2"
     />
     <InvestmentResult
       name="LCI / LCA"
-      :amount="investment.amount"
+      :amount="totalContributed"
       :interest-amount="resultLcx.interestAmount"
       :loading="!investment.di"
+      :breakdown="breakdownLcx"
     />
   </div>
 </template>
@@ -36,6 +39,7 @@
 <script setup lang='ts'>
 import InvestmentResult from '~/components/InvestmentResult.vue'
 import { computed } from 'vue'
+import { buildBreakdown, buildContributionSchedule, getRecurringCdbResult, getRecurringLcxResult, getRecurringPoupancaResult } from '~/src/aportes'
 import { getCDBResult } from '~/src/cdb'
 import { getLcxResult } from '~/src/lcx'
 import { getPoupancaResult } from '~/src/poupanca'
@@ -49,33 +53,55 @@ const periodMultiplier = {
   [PeriodTypes.Years]: 365,
 }
 
-const resultCDB = computed(() => {
-  return getCDBResult(
-    investment.amount,
-    investment.di,
-    investment.cdb,
-    getDurationInDays(),
-  )
-})
+// Deposit schedule shared by every product: the initial amount plus the
+// (optional) recurring contributions. When there is no recurring contribution
+// it holds a single deposit, so the results match the single-deposit case.
+const schedule = computed(() => buildContributionSchedule(
+  investment.amount,
+  investment.recurringAmount,
+  getFrequencyInDays(),
+  getDurationInDays(),
+  investment.inflationEnabled ? (investment.inflationRate ?? 0) : 0,
+))
 
-const resultLcx = computed(() => {
-  return getLcxResult(
-    investment.amount,
-    investment.di,
-    investment.lcx,
-    getDurationInDays(),
-  )
-})
+const totalContributed = computed(() =>
+  schedule.value.reduce((sum, contribution) => sum + contribution.principal, 0),
+)
 
-const resultPoupanca = computed(() => {
-  return getPoupancaResult(
-    investment.amount,
-    investment.poupanca,
-    getDurationInDays(),
-  )
-})
+const resultCDB = computed(() => getRecurringCdbResult(schedule.value, investment.di, investment.cdb))
+
+const resultLcx = computed(() => getRecurringLcxResult(schedule.value, investment.di, investment.lcx))
+
+const resultPoupanca = computed(() => getRecurringPoupancaResult(schedule.value, investment.poupanca))
+
+// Gross accumulation timeline per product, only when recurring contributions
+// are active. Each product grows a deposit with its own compounding rule.
+const hasRecurringContribution = computed(() => investment.recurringAmount > 0)
+
+const breakdownCDB = computed(() => buildProductBreakdown(
+  (principal, days) => principal + getCDBResult(principal, investment.di, investment.cdb, days).interestAmount,
+))
+
+const breakdownLcx = computed(() => buildProductBreakdown(
+  (principal, days) => principal + getLcxResult(principal, investment.di, investment.lcx, days).interestAmount,
+))
+
+const breakdownPoupanca = computed(() => buildProductBreakdown(
+  (principal, days) => principal + getPoupancaResult(principal, investment.poupanca, days).interestAmount,
+))
+
+function buildProductBreakdown(grow: (principal: number, days: number) => number) {
+  if (!hasRecurringContribution.value) {
+    return []
+  }
+  return buildBreakdown(schedule.value, getFrequencyInDays(), getDurationInDays(), grow)
+}
 
 function getDurationInDays() {
   return Math.floor(investment.period * periodMultiplier[investment.periodType])
+}
+
+function getFrequencyInDays() {
+  return Math.floor(investment.recurringFrequency * periodMultiplier[investment.recurringFrequencyType])
 }
 </script>

--- a/app/components/investment/RecurringContributionInput.vue
+++ b/app/components/investment/RecurringContributionInput.vue
@@ -91,26 +91,33 @@
 
       <div
         v-if="inflationEnabled"
-        class="relative mt-3"
+        class="mt-3"
       >
-        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-          <ion-icon
-            name="trending-up-outline"
-            size="small"
-            class="text-gray-400 dark:text-gray-500"
-            aria-hidden="true"
-          />
-        </div>
-        <input
-          id="inflation-rate-input"
-          v-model.number="inflationRate"
-          type="number"
-          min="0"
-          placeholder="Taxa de inflação"
-          class="block w-full pl-10 pr-16 py-2 border-b-2 border-gray-300 dark:border-gray-600 dark:bg-transparent text-gray-900 dark:text-white focus:border-blue-500 dark:focus:border-blue-400 focus:outline-none transition-colors"
+        <label
+          for="inflation-rate-input"
+          class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
         >
-        <div class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-          <span class="text-gray-500 dark:text-gray-400 text-sm">% ao ano</span>
+          Taxa de inflação
+        </label>
+        <div class="relative">
+          <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <ion-icon
+              name="trending-up-outline"
+              size="small"
+              class="text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+          </div>
+          <input
+            id="inflation-rate-input"
+            v-model.number="inflationRate"
+            type="number"
+            min="0"
+            class="block w-full pl-10 pr-16 py-2 border-b-2 border-gray-300 dark:border-gray-600 dark:bg-transparent text-gray-900 dark:text-white focus:border-blue-500 dark:focus:border-blue-400 focus:outline-none transition-colors"
+          >
+          <div class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+            <span class="text-gray-500 dark:text-gray-400 text-sm">% ao ano</span>
+          </div>
         </div>
       </div>
     </div>

--- a/app/components/investment/RecurringContributionInput.vue
+++ b/app/components/investment/RecurringContributionInput.vue
@@ -1,0 +1,164 @@
+<template>
+  <div class="mb-6">
+    <label
+      for="recurring-amount-input"
+      class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+    >
+      Aporte recorrente <span class="text-gray-400 dark:text-gray-500">(opcional)</span>
+    </label>
+    <div class="relative">
+      <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+        <ion-icon
+          name="repeat-outline"
+          size="small"
+          class="text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        />
+      </div>
+      <input
+        id="recurring-amount-input"
+        v-model.number="recurringAmount"
+        type="number"
+        min="0"
+        class="block w-full pl-10 pr-16 py-2 border-b-2 border-gray-300 dark:border-gray-600 dark:bg-transparent text-gray-900 dark:text-white focus:border-blue-500 dark:focus:border-blue-400 focus:outline-none transition-colors"
+      >
+      <div class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+        <span class="text-gray-500 dark:text-gray-400 text-sm">R$ ,00</span>
+      </div>
+    </div>
+
+    <div
+      v-if="hasRecurringContribution"
+      class="frequency-container"
+    >
+      <div class="mb-6 flex-1">
+        <label
+          for="recurring-frequency-input"
+          class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        >
+          A cada
+        </label>
+        <input
+          id="recurring-frequency-input"
+          v-model.number="recurringFrequency"
+          type="number"
+          min="1"
+          class="block w-full py-2 px-3 border-b-2 border-gray-300 dark:border-gray-600 dark:bg-transparent text-gray-900 dark:text-white focus:border-blue-500 dark:focus:border-blue-400 focus:outline-hidden transition-colors"
+        >
+      </div>
+      <div class="mb-6 flex-1">
+        <label
+          for="recurring-frequency-type-input"
+          class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        >
+          Frequência
+        </label>
+        <div class="relative">
+          <select
+            id="recurring-frequency-type-input"
+            v-model="recurringFrequencyType"
+            class="block w-full py-2 px-3 border-b-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:border-blue-500 dark:focus:border-blue-400 focus:outline-hidden transition-colors appearance-none cursor-pointer"
+          >
+            <option
+              v-for="option in periodTypesOptions"
+              :key="option"
+              :value="option"
+            >
+              {{ option }}
+            </option>
+          </select>
+          <div class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+            <ion-icon
+              name="chevron-down-outline"
+              size="small"
+              class="text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="hasRecurringContribution">
+      <label class="flex items-center gap-2 mt-1 cursor-pointer text-sm text-gray-700 dark:text-gray-300">
+        <input
+          v-model="inflationEnabled"
+          type="checkbox"
+          class="cursor-pointer"
+        >
+        Corrigir aportes pela inflação
+      </label>
+
+      <div
+        v-if="inflationEnabled"
+        class="relative mt-3"
+      >
+        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          <ion-icon
+            name="trending-up-outline"
+            size="small"
+            class="text-gray-400 dark:text-gray-500"
+            aria-hidden="true"
+          />
+        </div>
+        <input
+          id="inflation-rate-input"
+          v-model.number="inflationRate"
+          type="number"
+          min="0"
+          placeholder="Taxa de inflação"
+          class="block w-full pl-10 pr-16 py-2 border-b-2 border-gray-300 dark:border-gray-600 dark:bg-transparent text-gray-900 dark:text-white focus:border-blue-500 dark:focus:border-blue-400 focus:outline-none transition-colors"
+        >
+        <div class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+          <span class="text-gray-500 dark:text-gray-400 text-sm">% ao ano</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang='ts'>
+import { computed } from 'vue'
+import { PeriodTypes, useInvestmentStore } from '~/store/investment'
+
+const store = useInvestmentStore()
+
+const periodTypesOptions = computed(() => Object.values(PeriodTypes))
+
+const recurringAmount = computed({
+  get: () => store.recurringAmount,
+  set: newValue => store.setRecurringAmount(Number(newValue) > 0 ? Number(newValue) : 0),
+})
+
+const hasRecurringContribution = computed(() => store.recurringAmount > 0)
+
+const recurringFrequency = computed({
+  get: () => store.recurringFrequency,
+  set: newValue => store.setRecurringFrequency(Number(newValue) > 0 ? Number(newValue) : 1),
+})
+
+const recurringFrequencyType = computed({
+  get: () => store.recurringFrequencyType,
+  set: newType => store.setRecurringFrequencyType(newType),
+})
+
+const inflationEnabled = computed({
+  get: () => store.inflationEnabled,
+  set: enabled => store.setInflationEnabled(enabled),
+})
+
+const inflationRate = computed({
+  get: () => store.inflationRate,
+  set: newRate => store.setInflationRate(Number(newRate) > 0 ? Number(newRate) : 0),
+})
+</script>
+
+<style scoped>
+.frequency-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+</style>

--- a/app/src/aportes.ts
+++ b/app/src/aportes.ts
@@ -1,0 +1,138 @@
+import { getCDBResult } from './cdb'
+import { getLcxResult } from './lcx'
+import { getPoupancaResult } from './poupanca'
+
+export interface Contribution {
+  principal: number
+  depositDay: number
+  days: number
+}
+
+export interface BreakdownEntry {
+  day: number
+  contributed: number
+  balance: number
+  interest: number
+}
+
+// Builds the list of deposits made over the investment horizon: the initial
+// amount at day 0 plus one recurring contribution every `frequencyDays` until
+// (but not including) the redemption day. Each deposit keeps its own holding
+// period so taxes can be computed per deposit. When `inflationRate` (yearly %)
+// is greater than zero, recurring contributions are corrected by inflation to
+// keep their purchasing power constant over time.
+export function buildContributionSchedule(
+  initialAmount: number,
+  recurringAmount: number,
+  frequencyDays: number,
+  totalDays: number,
+  inflationRate: number,
+): Contribution[] {
+  const schedule: Contribution[] = []
+
+  if (initialAmount > 0) {
+    schedule.push({ principal: initialAmount, depositDay: 0, days: totalDays })
+  }
+
+  if (recurringAmount > 0 && frequencyDays > 0) {
+    for (let day = frequencyDays; day < totalDays; day += frequencyDays) {
+      const inflationFactor = Math.pow(1 + inflationRate / 100, day / 365)
+      schedule.push({
+        principal: recurringAmount * inflationFactor,
+        depositDay: day,
+        days: totalDays - day,
+      })
+    }
+  }
+
+  return schedule
+}
+
+export function getRecurringCdbResult(
+  schedule: Contribution[],
+  di: number,
+  yearlyIndex: number,
+): { interestAmount: number, taxAmount: number, taxPercentage: number, iofAmount: number } {
+  let interestAmount = 0
+  let taxAmount = 0
+  let iofAmount = 0
+
+  for (const contribution of schedule) {
+    const result = getCDBResult(contribution.principal, di, yearlyIndex, contribution.days)
+    interestAmount += result.interestAmount
+    taxAmount += result.taxAmount
+    iofAmount += result.iofAmount
+  }
+
+  const taxableBase = interestAmount - iofAmount
+  const taxPercentage = taxableBase > 0 ? (taxAmount / taxableBase) * 100 : 0
+
+  return { interestAmount, taxAmount, taxPercentage, iofAmount }
+}
+
+export function getRecurringLcxResult(
+  schedule: Contribution[],
+  di: number,
+  yearlyIndex: number,
+): { interestAmount: number } {
+  let interestAmount = 0
+  for (const contribution of schedule) {
+    interestAmount += getLcxResult(contribution.principal, di, yearlyIndex, contribution.days).interestAmount
+  }
+  return { interestAmount }
+}
+
+export function getRecurringPoupancaResult(
+  schedule: Contribution[],
+  index: number,
+): { interestAmount: number } {
+  let interestAmount = 0
+  for (const contribution of schedule) {
+    interestAmount += getPoupancaResult(contribution.principal, index, contribution.days).interestAmount
+  }
+  return { interestAmount }
+}
+
+// Builds a period-by-period timeline of the gross accumulation (before taxes,
+// which are only realized at redemption). Each entry is a cumulative snapshot
+// of how much was contributed and how much the balance is worth at that day.
+// When the number of intervals exceeds `maxRows`, snapshots are aggregated into
+// wider buckets so the breakdown stays readable. `grow` returns the value of a
+// principal (including itself) after being invested for a given number of days,
+// letting each product apply its own compounding rule.
+export function buildBreakdown(
+  schedule: Contribution[],
+  frequencyDays: number,
+  totalDays: number,
+  grow: (principal: number, days: number) => number,
+  maxRows = 24,
+): BreakdownEntry[] {
+  if (frequencyDays <= 0 || totalDays <= 0) {
+    return []
+  }
+
+  const marks = Math.floor(totalDays / frequencyDays)
+  const bucketFactor = marks > maxRows ? Math.ceil(marks / maxRows) : 1
+  const stepDays = frequencyDays * bucketFactor
+
+  const snapshotDays = new Set<number>()
+  for (let day = stepDays; day < totalDays; day += stepDays) {
+    snapshotDays.add(day)
+  }
+  snapshotDays.add(totalDays)
+
+  const entries: BreakdownEntry[] = []
+  for (const day of snapshotDays) {
+    let contributed = 0
+    let balance = 0
+    for (const contribution of schedule) {
+      if (contribution.depositDay <= day) {
+        contributed += contribution.principal
+        balance += grow(contribution.principal, day - contribution.depositDay)
+      }
+    }
+    entries.push({ day, contributed, balance, interest: balance - contributed })
+  }
+
+  return entries
+}

--- a/app/store/investment.ts
+++ b/app/store/investment.ts
@@ -18,6 +18,11 @@ export const useInvestmentStore = defineStore('investment', {
       lcx: 100,
       poupanca: null as number | null,
       selic: null as number | null,
+      recurringAmount: 0,
+      recurringFrequency: 1,
+      recurringFrequencyType: PeriodTypes.Months,
+      inflationEnabled: false,
+      inflationRate: null as number | null,
     }
   },
   actions: {
@@ -41,6 +46,21 @@ export const useInvestmentStore = defineStore('investment', {
     },
     setSelic(newSelic: number) {
       this.selic = newSelic
+    },
+    setRecurringAmount(newAmount: number) {
+      this.recurringAmount = newAmount
+    },
+    setRecurringFrequency(newFrequency: number) {
+      this.recurringFrequency = newFrequency
+    },
+    setRecurringFrequencyType(newType: PeriodTypes) {
+      this.recurringFrequencyType = newType
+    },
+    setInflationEnabled(enabled: boolean) {
+      this.inflationEnabled = enabled
+    },
+    setInflationRate(newRate: number) {
+      this.inflationRate = newRate
     },
     initializeStore() {
       this.loadIndexes()

--- a/test/unit/src/aportes.spec.ts
+++ b/test/unit/src/aportes.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildContributionSchedule,
+  buildBreakdown,
+  getRecurringCdbResult,
+  getRecurringLcxResult,
+  getRecurringPoupancaResult,
+} from '../../../app/src/aportes'
+import { getCDBResult } from '../../../app/src/cdb'
+import { getLcxResult } from '../../../app/src/lcx'
+import { getPoupancaResult } from '../../../app/src/poupanca'
+
+describe('buildContributionSchedule', () => {
+  it('returns only the initial deposit when there is no recurring contribution', () => {
+    const schedule = buildContributionSchedule(1000, 0, 30, 360, 0)
+    expect(schedule).toEqual([{ principal: 1000, depositDay: 0, days: 360 }])
+  })
+
+  it('adds one deposit per period, each with its own holding period', () => {
+    const schedule = buildContributionSchedule(1000, 100, 30, 90, 0)
+    expect(schedule).toEqual([
+      { principal: 1000, depositDay: 0, days: 90 },
+      { principal: 100, depositDay: 30, days: 60 },
+      { principal: 100, depositDay: 60, days: 30 },
+    ])
+  })
+
+  it('does not add a contribution landing exactly on the redemption day', () => {
+    const schedule = buildContributionSchedule(0, 100, 30, 60, 0)
+    // deposits at day 30 only; day 60 == redemption earns nothing and is skipped
+    expect(schedule).toEqual([{ principal: 100, depositDay: 30, days: 30 }])
+  })
+
+  it('corrects recurring contributions by inflation, leaving the initial deposit untouched', () => {
+    const inflationRate = 6
+    const schedule = buildContributionSchedule(1000, 100, 365, 730, inflationRate)
+
+    expect(schedule[0]).toEqual({ principal: 1000, depositDay: 0, days: 730 })
+    // contribution at day 365 corrected by (1 + 6%)^(365/365)
+    expect(schedule[1]!.principal).toBeCloseTo(100 * Math.pow(1.06, 1), 10)
+    expect(schedule[1]!.depositDay).toBe(365)
+  })
+
+  it('skips recurring deposits when the amount is zero (no regression to single deposit)', () => {
+    const schedule = buildContributionSchedule(1000, 0, 30, 360, 6)
+    expect(schedule).toHaveLength(1)
+  })
+})
+
+describe('getRecurringCdbResult', () => {
+  it('matches the single-deposit result when there is only the initial deposit', () => {
+    const schedule = buildContributionSchedule(1000, 0, 30, 400, 0)
+    const recurring = getRecurringCdbResult(schedule, 100, 13.15)
+    const single = getCDBResult(1000, 100, 13.15, 400)
+
+    expect(recurring.interestAmount).toBeCloseTo(single.interestAmount, 6)
+    expect(recurring.iofAmount).toBeCloseTo(single.iofAmount, 6)
+    expect(recurring.taxAmount).toBeCloseTo(single.taxAmount, 6)
+    expect(recurring.taxPercentage).toBeCloseTo(single.taxPercentage, 6)
+  })
+
+  it('sums per-deposit taxes, applying IOF to contributions held under 30 days', () => {
+    const di = 100
+    const yearlyIndex = 13.15
+    const schedule = buildContributionSchedule(1000, 500, 15, 40, 0)
+
+    let interestAmount = 0
+    let taxAmount = 0
+    let iofAmount = 0
+    let iofHitLastDeposit = false
+    for (const contribution of schedule) {
+      const result = getCDBResult(contribution.principal, di, yearlyIndex, contribution.days)
+      interestAmount += result.interestAmount
+      taxAmount += result.taxAmount
+      iofAmount += result.iofAmount
+      if (contribution.days <= 30) {
+        iofHitLastDeposit = iofHitLastDeposit || result.iofAmount > 0
+      }
+    }
+
+    const result = getRecurringCdbResult(schedule, di, yearlyIndex)
+    expect(iofHitLastDeposit).toBe(true) // last deposits held < 30 days pay IOF
+    expect(result.interestAmount).toBeCloseTo(interestAmount, 6)
+    expect(result.taxAmount).toBeCloseTo(taxAmount, 6)
+    expect(result.iofAmount).toBeCloseTo(iofAmount, 6)
+  })
+
+  it('reports a blended effective tax percentage', () => {
+    const schedule = buildContributionSchedule(1000, 500, 90, 400, 0)
+    const result = getRecurringCdbResult(schedule, 100, 13.15)
+    const expected = (result.taxAmount / (result.interestAmount - result.iofAmount)) * 100
+    expect(result.taxPercentage).toBeCloseTo(expected, 6)
+  })
+})
+
+describe('getRecurringLcxResult / getRecurringPoupancaResult', () => {
+  it('sums LCI/LCA interest per deposit without taxes', () => {
+    const schedule = buildContributionSchedule(1000, 200, 60, 360, 0)
+    const expected = schedule.reduce(
+      (sum, c) => sum + getLcxResult(c.principal, 100, 95, c.days).interestAmount,
+      0,
+    )
+    expect(getRecurringLcxResult(schedule, 100, 95).interestAmount).toBeCloseTo(expected, 6)
+  })
+
+  it('sums Poupança interest per deposit', () => {
+    const schedule = buildContributionSchedule(1000, 200, 30, 360, 0)
+    const expected = schedule.reduce(
+      (sum, c) => sum + getPoupancaResult(c.principal, 0.5, c.days).interestAmount,
+      0,
+    )
+    expect(getRecurringPoupancaResult(schedule, 0.5).interestAmount).toBeCloseTo(expected, 6)
+  })
+})
+
+describe('buildBreakdown', () => {
+  const grow = (principal: number, days: number) => principal * Math.pow(1.0002, days)
+
+  it('reports cumulative contributed amounts and interest per snapshot', () => {
+    const schedule = buildContributionSchedule(1000, 100, 30, 90, 0)
+    const entries = buildBreakdown(schedule, 30, 90, grow)
+
+    const last = entries.at(-1)!
+    expect(last.day).toBe(90)
+    // initial + two recurring deposits (day 30 and day 60)
+    expect(last.contributed).toBeCloseTo(1200, 6)
+    expect(last.interest).toBeCloseTo(last.balance - last.contributed, 6)
+    expect(last.balance).toBeGreaterThan(last.contributed)
+  })
+
+  it('always includes a snapshot on the redemption day', () => {
+    const schedule = buildContributionSchedule(1000, 100, 30, 100, 0)
+    const entries = buildBreakdown(schedule, 30, 100, grow)
+    expect(entries.at(-1)!.day).toBe(100)
+  })
+
+  it('aggregates into buckets when intervals exceed maxRows', () => {
+    // 365 daily contributions, capped at 12 rows
+    const schedule = buildContributionSchedule(1000, 10, 1, 365, 0)
+    const entries = buildBreakdown(schedule, 1, 365, grow, 12)
+    expect(entries.length).toBeLessThanOrEqual(13) // maxRows buckets + redemption day
+    expect(entries.at(-1)!.day).toBe(365)
+  })
+
+  it('returns an empty breakdown for invalid parameters', () => {
+    expect(buildBreakdown([], 0, 360, grow)).toEqual([])
+    expect(buildBreakdown([], 30, 0, grow)).toEqual([])
+  })
+})


### PR DESCRIPTION
## O que

Implementa a opção de aportes recorrentes solicitada na #133, com:

- **Aporte recorrente configurável** — valor + frequência flexível
  (dias, meses ou anos), aproveitando a mesma flexibilidade de período
  que a calculadora já oferece, em vez de assumir apenas aporte mensal.
- **Correção pela inflação (opcional)** — o usuário informa a taxa e
  cada aporte é corrigido para manter o poder de compra constante ao
  longo do tempo.
- **Breakdown por período** — cada card de resultado ganha uma tabela
  colapsável ("Ver evolução dos aportes") com a evolução do valor
  aportado, saldo bruto e juros ao longo do prazo.

## Por que

Aportes recorrentes são um recurso comum nesse tipo de calculadora e
dão uma visão realista de acúmulo com juros compostos ao longo do tempo.

## Detalhe importante: impostos por aporte

IR e IOF são calculados **por aporte**, respeitando o prazo de retenção
individual de cada depósito. Isso mantém a precisão fiscal quando os
últimos aportes ficam menos de 30 dias aplicados (sujeitos a IOF e à
faixa de IR mais alta) — um cálculo agregado simplificado erraria aqui.

Sem aporte recorrente, o comportamento é idêntico ao atual (o cronograma
tem um único depósito), garantindo que não há regressão.

Closes #133


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recurring investments, including optional periodic contributions and inflation-adjusted aportes.
  * Investment results can now show an expandable contribution breakdown with contributed amount, balance, and interest over time.
* **Bug Fixes**
  * Updated calculations to handle recurring deposits across supported investment types more accurately.
  * Preserved correct totals and breakdowns when recurring contributions are not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->