### PR TITLE
ci: Disable pnpm lifecycle scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
           check-latest: true
           cache: 'pnpm'
       - name: Install dependencies 👨🏻‍💻
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Prepare Nuxt
+        run: pnpm exec nuxt prepare
       - name: Lint check ✅
         run: pnpm lint
       - name: Tests 🧑‍🔬

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,9 @@ jobs:
           check-latest: true
           cache: 'pnpm'
       - name: Install dependencies 👨🏻‍💻
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Prepare Nuxt
+        run: pnpm exec nuxt prepare
       - name: Lint check ✅
         run: pnpm lint
       - name: Deploy 😎

--- a/.github/workflows/update-indexes.yml
+++ b/.github/workflows/update-indexes.yml
@@ -24,7 +24,7 @@ jobs:
           check-latest: true
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Update indicadores.json
         run: pnpm update-indexes
       - name: Checking for changes


### PR DESCRIPTION
Prevent automatic dependency lifecycle scripts from running during GitHub Actions installs.

SonarQube flags the current install commands because compromised packages could execute arbitrary code through lifecycle hooks. All three workflows now install with `--ignore-scripts`. The CI and publishing jobs explicitly run `pnpm exec nuxt prepare` because their lint and generation steps require Nuxt-generated files; the standalone index updater does not load Nuxt.

This preserves the existing workflow behavior while reducing supply-chain exposure. The change was validated with `pnpm lint`, `pnpm test` (81 tests), and `pnpm generate`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated workflow reliability by separating dependency installation from application preparation.
  * Dependency installation now skips lifecycle scripts for more predictable CI, publishing, and index update runs.
  * Added an explicit application preparation step before linting and publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->